### PR TITLE
Fix num (double error) & Time out

### DIFF
--- a/lib/screens/confirmation_screen.dart
+++ b/lib/screens/confirmation_screen.dart
@@ -20,7 +20,7 @@ class ConfirmationScreen extends StatelessWidget {
       final warmthData =
           await _imageClassificationService.classifyImage(File(imagePath));
 
-      final warmthIndex = (warmthData['warmth_index'])?.toDouble() ?? 0.0;
+      final warmthIndex = (warmthData['warmth_index'] as num?)?.toDouble() ?? 0.0;
 
       Navigator.pop(context);
       Navigator.pushNamed(context, '/additional-info', arguments: warmthIndex);

--- a/lib/services/image_classification_service.dart
+++ b/lib/services/image_classification_service.dart
@@ -8,9 +8,9 @@ class ImageClassificationService {
   ImageClassificationService()
       : _dio = Dio(
           BaseOptions(
-            connectTimeout: const Duration(seconds: 120),
-            receiveTimeout: const Duration(seconds: 120),
-            sendTimeout: const Duration(seconds: 120),
+            connectTimeout: const Duration(seconds: 60),
+            receiveTimeout: const Duration(seconds: 60),
+            sendTimeout: const Duration(seconds: 60),
           ),
         );
 


### PR DESCRIPTION
Here are my latest updates for the SSH warmth flutter. The code that I fixes are in the Fix num (double error) & Time out in the confirmation_screen.dart and image_classification_service.dart